### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,5 @@
 class ItemsController < ApplicationController
+  before_action :move_to_index, only: :edit
   def index
     query = 'SELECT * FROM items ORDER BY id DESC '
     @items = Item.find_by_sql(query)
@@ -27,7 +28,13 @@ class ItemsController < ApplicationController
   end
 
   def update
-
+    @item = Item.find(params[:id])
+    @item.update(item_params)
+    if @item.save
+      redirect_to item_path(@item.id)
+    else
+      render :edit
+    end
   end
 
   private
@@ -35,5 +42,10 @@ class ItemsController < ApplicationController
   def item_params
     params.require(:item).permit(:item_name, :image, :detail, :price, :category_id, :quality_id, :postage_id, :prefecture_id,
                                  :term_id).merge(user_id: current_user.id)
+  end
+
+  def move_to_index
+    item = Item.find(params[:id])
+    redirect_to action: :index unless user_signed_in? && current_user.id == item.user_id
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -22,6 +22,14 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def edit
+    @item = Item.find(params[:id])
+  end
+
+  def update
+
+  end
+
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,5 @@
 class ItemsController < ApplicationController
+  before_action :set_item, only: [:show, :edit, :update]
   before_action :move_to_index, only: :edit
   def index
     query = 'SELECT * FROM items ORDER BY id DESC '
@@ -20,16 +21,13 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def edit
-    @item = Item.find(params[:id])
   end
 
   def update
-    @item = Item.find(params[:id])
-    @item.update(item_params)
+    @item.new(item_params)
     if @item.save
       redirect_to item_path(@item.id)
     else
@@ -47,5 +45,9 @@ class ItemsController < ApplicationController
   def move_to_index
     item = Item.find(params[:id])
     redirect_to action: :index unless user_signed_in? && current_user.id == item.user_id
+  end
+
+  def set_item
+    @item = Item.find(params[:id])
   end
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,11 +7,9 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with(model: @item, local: true) do |f| %>
+    <%= form_with(model: @item, local: true ) do |f| %>
 
-      <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
       <%= render 'shared/error_messages', model: f.object %>
-      <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
       <div class="img-upload">
         <div class="weight-bold-text">
@@ -80,7 +78,7 @@ app/assets/stylesheets/items/new.css %>
           <%= f.collection_select(:term_id, Term.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
         </div>
       </div>
-  
+
       <div class="sell-price">
         <div class="weight-bold-text question-text">
           <span>販売価格<br>(¥300〜9,999,999)</span>
@@ -109,9 +107,6 @@ app/assets/stylesheets/items/new.css %>
           </div>
         </div>
       </div>
-      <%# /販売価格 %>
-
-      <%# 注意書き %>
       <div class="caution">
         <p class="sentence">
           <a href="#">禁止されている出品、</a>
@@ -129,13 +124,10 @@ app/assets/stylesheets/items/new.css %>
           に同意したことになります。
         </p>
       </div>
-      <%# /注意書き %>
-      <%# 下部ボタン %>
       <div class="sell-btn-contents">
-        <%= f.submit "変更する" ,class:"sell-btn" %>
-        <%=link_to 'もどる', "#", class:"back-btn" %>
+        <%= f.submit "変更する", class:"sell-btn" %>
+        <%= link_to 'もどる', item_path(@item.id), class:"back-btn" %>
       </div>
-      <%# /下部ボタン %>
     <% end %>
   </div>
 

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,145 +7,137 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with(model: @item, local: true) do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+      <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+      <%= render 'shared/error_messages', model: f.object %>
+      <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
-    <%# 商品画像 %>
-    <div class="img-upload">
-      <div class="weight-bold-text">
-        商品画像
-        <span class="indispensable">必須</span>
-      </div>
-      <div class="click-upload">
-        <p>
-          クリックしてファイルをアップロード
-        </p>
-        <%= f.file_field :hoge, id:"item-image" %>
-      </div>
-    </div>
-    <%# /商品画像 %>
-    <%# 商品名と商品説明 %>
-    <div class="new-items">
-      <div class="weight-bold-text">
-        商品名
-        <span class="indispensable">必須</span>
-      </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
-      <div class="items-explain">
+      <div class="img-upload">
         <div class="weight-bold-text">
-          商品の説明
+          商品画像
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <div class="click-upload">
+          <p>
+            クリックしてファイルをアップロード
+          </p>
+          <%= f.file_field :image, id:"item-image" %>
+        </div>
       </div>
-    </div>
-    <%# /商品名と商品説明 %>
 
-    <%# 商品の詳細 %>
-    <div class="items-detail">
-      <div class="weight-bold-text">商品の詳細</div>
-      <div class="form">
+      <div class="new-items">
         <div class="weight-bold-text">
-          カテゴリー
+          商品名
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
-        <div class="weight-bold-text">
-          商品の状態
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
-      </div>
-    </div>
-    <%# /商品の詳細 %>
-
-    <%# 配送について %>
-    <div class="items-detail">
-      <div class="weight-bold-text question-text">
-        <span>配送について</span>
-        <a class="question" href="#">?</a>
-      </div>
-      <div class="form">
-        <div class="weight-bold-text">
-          配送料の負担
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
-        <div class="weight-bold-text">
-          発送元の地域
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
-        <div class="weight-bold-text">
-          発送までの日数
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
-      </div>
-    </div>
-    <%# /配送について %>
-
-    <%# 販売価格 %>
-    <div class="sell-price">
-      <div class="weight-bold-text question-text">
-        <span>販売価格<br>(¥300〜9,999,999)</span>
-        <a class="question" href="#">?</a>
-      </div>
-      <div>
-        <div class="price-content">
-          <div class="price-text">
-            <span>価格</span>
+        <%= f.text_area :item_name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+        <div class="items-explain">
+          <div class="weight-bold-text">
+            商品の説明
             <span class="indispensable">必須</span>
           </div>
-          <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
-        </div>
-        <div class="price-content">
-          <span>販売手数料 (10%)</span>
-          <span>
-            <span id='add-tax-price'></span>円
-          </span>
-        </div>
-        <div class="price-content">
-          <span>販売利益</span>
-          <span>
-            <span id='profit'></span>円
-          </span>
+          <%= f.text_area :detail, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
         </div>
       </div>
-    </div>
-    <%# /販売価格 %>
 
-    <%# 注意書き %>
-    <div class="caution">
-      <p class="sentence">
-        <a href="#">禁止されている出品、</a>
-        <a href="#">行為</a>
-        を必ずご確認ください。
-      </p>
-      <p class="sentence">
-        またブランド品でシリアルナンバー等がある場合はご記載ください。
-        <a href="#">偽ブランドの販売</a>
-        は犯罪であり処罰される可能性があります。
-      </p>
-      <p class="sentence">
-        また、出品をもちまして
-        <a href="#">加盟店規約</a>
-        に同意したことになります。
-      </p>
-    </div>
-    <%# /注意書き %>
-    <%# 下部ボタン %>
-    <div class="sell-btn-contents">
-      <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
-    </div>
-    <%# /下部ボタン %>
+      <div class="items-detail">
+        <div class="weight-bold-text">商品の詳細</div>
+        <div class="form">
+          <div class="weight-bold-text">
+            カテゴリー
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
+          <div class="weight-bold-text">
+            商品の状態
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select(:quality_id, Quality.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
+        </div>
+      </div>
+
+      <div class="items-detail">
+        <div class="weight-bold-text question-text">
+          <span>配送について</span>
+          <a class="question" href="#">?</a>
+        </div>
+        <div class="form">
+          <div class="weight-bold-text">
+            配送料の負担
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select(:postage_id, Postage.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+          <div class="weight-bold-text">
+            発送元の地域
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
+          <div class="weight-bold-text">
+            発送までの日数
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select(:term_id, Term.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        </div>
+      </div>
+  
+      <div class="sell-price">
+        <div class="weight-bold-text question-text">
+          <span>販売価格<br>(¥300〜9,999,999)</span>
+          <a class="question" href="#">?</a>
+        </div>
+        <div>
+          <div class="price-content">
+            <div class="price-text">
+              <span>価格</span>
+              <span class="indispensable">必須</span>
+            </div>
+            <span class="sell-yen">¥</span>
+            <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          </div>
+          <div class="price-content">
+            <span>販売手数料 (10%)</span>
+            <span>
+              <span id='add-tax-price'></span>円
+            </span>
+          </div>
+          <div class="price-content">
+            <span>販売利益</span>
+            <span>
+              <span id='profit'></span>円
+            </span>
+          </div>
+        </div>
+      </div>
+      <%# /販売価格 %>
+
+      <%# 注意書き %>
+      <div class="caution">
+        <p class="sentence">
+          <a href="#">禁止されている出品、</a>
+          <a href="#">行為</a>
+          を必ずご確認ください。
+        </p>
+        <p class="sentence">
+          またブランド品でシリアルナンバー等がある場合はご記載ください。
+          <a href="#">偽ブランドの販売</a>
+          は犯罪であり処罰される可能性があります。
+        </p>
+        <p class="sentence">
+          また、出品をもちまして
+          <a href="#">加盟店規約</a>
+          に同意したことになります。
+        </p>
+      </div>
+      <%# /注意書き %>
+      <%# 下部ボタン %>
+      <div class="sell-btn-contents">
+        <%= f.submit "変更する" ,class:"sell-btn" %>
+        <%=link_to 'もどる', "#", class:"back-btn" %>
+      </div>
+      <%# /下部ボタン %>
+    <% end %>
   </div>
-  <% end %>
 
   <footer class="items-sell-footer">
     <ul class="menu">

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -100,8 +100,8 @@
           <span>販売利益</span>
           <span>
             <span id='profit'></span>円
+          </span>
         </div>
-        </span>
       </div>
     </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,7 +23,7 @@
     </div>
 
     <% if user_signed_in? && current_user.id == @item.user.id %>
-      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+      <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
       <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
     <% elsif user_signed_in? && current_user.id != @item.user.id %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [ :index, :new, :create, :show]
+  resources :items, only: [ :index, :new, :create, :show, :edit, :update]
   
 end


### PR DESCRIPTION
# What
商品編集ページ作成
# Why
商品編集機能実装のため

・ログイン状態のユーザーは商品編集ページに遷移できる
https://gyazo.com/27f5b05e2cc8bf755a787e14eaeec707
・必要な情報を入力して更新するを押すと商品情報を変更できる
https://gyazo.com/60a4bd8a33333d4de5b07db42d54688a
・入力に問題がある状態で更新するを押すとエラーメッセージが出る
https://gyazo.com/cb40a5ce001f579eb1dafa9471c002bb
・何も編集せずに更新するを押しても画像なしにならない
https://gyazo.com/bb872cd8c757aad641345ae0f3fc3ac2
・ログイン状態でも自信が出品していない商品編集ページにいくとルートパスにリダイレクトする
https://gyazo.com/755781c278649f22487e58e8c63e4fb9
・ログアウト状態で商品編集ページに行こうとするとルートパスに遷移する
https://gyazo.com/09540c0ffcadd93ef4baa44c64c14be7
・既存の情報は商品編集画面を開いた時点で表示される
https://gyazo.com/4f95453fd5915c7c2ce1e9f6b1c0f739

